### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/mozilla/addons.png?label=ready&title=Ready)](https://waffle.io/mozilla/addons)
 This is the general root for add-ons at Mozilla.
 
 Documentation? See: https://addons.readthedocs.org


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/mozilla/addons

This was requested by a real person (user muffinresearch) on waffle.io, we're not trying to spam you.