### PR TITLE
Instruct push hero to change IRC topic

### DIFF
--- a/docs/server/push-duty.rst
+++ b/docs/server/push-duty.rst
@@ -98,6 +98,9 @@ that the push is done with any issues. Here's the template:
 
 .. literalinclude:: /server/push_email.tpl
 
+Set the topic of the #amo channel to include the new etherpad link and the IRC nick of next
+week's push hero.
+
 Future Goals
 ------------
 


### PR DESCRIPTION
This helps me (and others):

* see at a glance who is responsible for the push right from their IRC clients
* clear out my add-ons tagging/pushing meetings this week if it's not me