### PR TITLE
Document tagging addons-frontend

### DIFF
--- a/docs/server/push-duty.rst
+++ b/docs/server/push-duty.rst
@@ -23,6 +23,7 @@ The code that will go in production on Thursday is tagged on Tuesday. The
 following repositories are tagged:
 
     * `addons-server <https://github.com/mozilla/addons-server/>`_
+    * `addons-frontend <https://github.com/mozilla/addons-frontend/>`_
 
 Tags are of the format: ``YYYY.MM.DD``,
 

--- a/docs/ux/disco-pane.rst
+++ b/docs/ux/disco-pane.rst
@@ -12,7 +12,7 @@ May 25
 .. image:: ../images/disco-pane.png
 
 `Intro Video <https://github.com/mozilla/addons/issues/83>`_
------------
+------------------------------------------------------------
 .. image:: ../images/video-thumb.png
 
 * When a user clicks "Click to play", the copy to the left of the video thumbnail will fade away and the thumbnail will expand down and to the left.
@@ -22,7 +22,7 @@ May 25
 * When a user clicks "close video" below the expanded video, the video will shrink up and to the right back to its original position. The copy to the left will fade back in.
 
 `Switch Interaction <https://github.com/mozilla/addons/issues/63>`_
-------------------
+-------------------------------------------------------------------
 
 .. image:: ../images/switch.png
 


### PR DESCRIPTION
We need to land https://github.com/mozilla/addons-frontend/pull/505/files for that command to work. Hoping to automate this at some point but not yet.