### PR TITLE
Change push duty URLs to the same format as tags

### DIFF
--- a/docs/server/push-duty.rst
+++ b/docs/server/push-duty.rst
@@ -71,7 +71,7 @@ tagging::
 .. note:: Here we are using ``upstream`` and ``security`` remotes, which point
   to ``mozilla/addons-server`` and ``mozilla/addons-server-security``,
   respectively. If your configuration is different you can substitute
-  ``upstream`` and ``security`` for whatever you call the 
+  ``upstream`` and ``security`` for whatever you call the
   ``mozilla/addons-server`` and ``mozilla/addons-server-security``
   repositories' remotes.
 
@@ -194,7 +194,7 @@ Once complete
 
 Create a new etherpad page for the *next push*, for example:
 
-https://public.etherpad-mozilla.org/p/amo-2015-11-12
+https://public.etherpad-mozilla.org/p/amo-2016.10.06
 
 You can use this handy template:
 

--- a/docs/server/push_email.tpl
+++ b/docs/server/push_email.tpl
@@ -1,11 +1,11 @@
 This week's push is done!
 
 Notes:
-    https://public.etherpad-mozilla.org/p/amo-YYYY-MM-DD
+    https://public.etherpad-mozilla.org/p/amo-YYYY.MM.DD
 
 Issues:
     None
 
 Next Push:
     <push hero>
-    https://public.etherpad-mozilla.org/p/amo-YYYY-MM-DD
+    https://public.etherpad-mozilla.org/p/amo-YYYY.MM.DD


### PR DESCRIPTION
@mstriemer kindly started doing this last week and it's much nicer. Let's put it in the docs so copypasta doesn't revert to the bad old days of dashes!