### PR TITLE
Fixed CoC link syntax

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
 Code of conduct
 ===============
 
-This repository is governed by Mozilla's code of conduct and etiquette guidelines. For more details please see the [Mozilla Community Participation Guidelines] (https://www.mozilla.org/about/governance/policies/participation/) and [Developer Etiquette Guidelines] (https://bugzilla.mozilla.org/page.cgi?id=etiquette.html).
+This repository is governed by Mozilla's code of conduct and etiquette guidelines. For more details please see the [Mozilla Community Participation Guidelines](https://www.mozilla.org/about/governance/policies/participation/) and [Developer Etiquette Guidelines](https://bugzilla.mozilla.org/page.cgi?id=etiquette.html).


### PR DESCRIPTION
The link was not correctly displayed because there was a space between the [title] (http://and/the/url)