### PR TITLE
Indicate the customary time that code is frozen and tagged

### DIFF
--- a/docs/server/push-duty.rst
+++ b/docs/server/push-duty.rst
@@ -16,8 +16,9 @@ Before the push
 ---------------
 
 
-The code that will go in production on Thursday is tagged on Tuesday. The
-following repositories are tagged:
+The code that will go in production on Thursday is tagged on Tuesday
+at `16:00 GMT <http://www.timebie.com/std/gmt.php?q=16>`_.
+The following repositories are tagged:
 
     * `addons-server <https://github.com/mozilla/addons-server/>`_
     * `addons-frontend <https://github.com/mozilla/addons-frontend/>`_

--- a/docs/server/push-duty.rst
+++ b/docs/server/push-duty.rst
@@ -17,7 +17,7 @@ Before the push
 
 
 The code that will go in production on Thursday is tagged on Tuesday
-at `16:00 GMT <http://www.timebie.com/std/gmt.php?q=16>`_.
+at `09:00 PT <http://www.timebie.com/std/pst.php?q=9>`_.
 The following repositories are tagged:
 
     * `addons-server <https://github.com/mozilla/addons-server/>`_


### PR DESCRIPTION
As per the discussion in IRC, it probably makes sense to add this to our docs.