### PR TITLE
Add link to __frontend_version__ on -stage

### DIFF
--- a/docs/server/push-duty.rst
+++ b/docs/server/push-duty.rst
@@ -145,6 +145,7 @@ You can also check ``/__version__`` on a given service which shows the currently
 deployed revision and tag e.g:
 
  * `Addons Server (stage) <https://addons.allizom.org/__version__>`_
+ * `Addons Frontend (stage) <https://addons.allizom.org/__frontend_version__>`_
  * `Addons Frontend Disco Pane (stage) <https://discovery.addons.allizom.org/__version__>`_
 
 Before the push


### PR DESCRIPTION
Would it make sense to add this link in the list of version links to check?