### PR TITLE
Remove sudo from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: false
 python:
   - "2.7"
 env:


### PR DESCRIPTION
`sudo` has been removed a while ago.

https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration#timeline---its-happening-fast