### PR TITLE
Indicate that part of push duty is to do the l10n extraction

### DIFF
--- a/docs/server/push-duty.rst
+++ b/docs/server/push-duty.rst
@@ -150,7 +150,7 @@ deployed revision and tag e.g:
 Frontend L10n
 +++++++++++++
 
-After you tag the ``addons-frontend`` repository, please remind someone on that team to `extract and merge the L10n strings <https://github.com/mozilla/addons-frontend/blob/master/docs/i18n.md>`_.
+After you tag the ``addons-frontend`` repository, please `extract and merge the L10n strings <https://github.com/mozilla/addons-frontend/blob/master/docs/i18n.md>`_.
 
 Before the push
 +++++++++++++++


### PR DESCRIPTION
Update push duty docs to indicate that part of the duties includes doing l10n extraction