### PR TITLE
Remove bugzilla from linkcheck ignore list

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -312,6 +312,4 @@ linkcheck_ignore = [
     'https://chat.mozilla.org/#/room/#amo:mozilla.org',
     # Ignore about: pages
     r'about:.*',
-    # Ignore bugzilla buglist pages since they require cookies apparently
-    r'https://bugzilla\.mozilla\.org/buglist\.cgi\?.*',
 ]


### PR DESCRIPTION
Failed link checks to bugzilla buglists turned out to be a bug that has been identified and fixed: https://bugzilla.mozilla.org/show_bug.cgi?id=1668299