### PR TITLE
Use issue types and forms

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,9 +1,0 @@
-### Describe the problem and steps to reproduce it:
-(Please include as many details as possible.)
-
-### What happened?
-
-### What did you expect to happen?
-
-### Anything else we should know?
-(Please include a link to the page, screenshots and any relevant files.)

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,36 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: ["type:bug", "needs:info"]
+projects: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Include in detailed steps how to reproduce the bug you encountered
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-expected
+    attributes:
+      label: What did you expect to happen?
+      description: Include details
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the bug you encountered.
+      options:
+      - label: I have searched the existing issues
+        required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: AMO Matrix channel
+    url: https://matrix.to/#/#amo:mozilla.org
+    about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/task-addons-frontend.yml
+++ b/.github/ISSUE_TEMPLATE/task-addons-frontend.yml
@@ -1,0 +1,38 @@
+name: Task (addons-frontend)
+description: Filing a task (contributors only)
+title: "[Task]: "
+labels: ["type:feature", "needs:info", "repository:addons-frontend"]
+projects: []
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: |
+        A few sentences describing what the task aims to achieve. It can be a simple sentence or a story formatted paragraph.
+        Be concise and detailed. Avoid vague terms and include relevant links.
+      placeholder: |
+        As a <blank>, I want to <blank, so that I can <blank>
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: List of milestones or checkpoints that if met verify the task has been completed.
+      value: |
+        ```[tasklist]
+          ### Acceptance Criteria
+          - [ ] 
+          ```
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      description: Checks before submitting the issue
+      options:
+        -
+          label: If the issue is ready to work on, I have removed the "needs:info" label and added an assignee.
+          required: true

--- a/.github/ISSUE_TEMPLATE/task-addons-server.yml
+++ b/.github/ISSUE_TEMPLATE/task-addons-server.yml
@@ -1,0 +1,38 @@
+name: Task (addons-server)
+description: Filing a task (contributors only)
+title: "[Task]: "
+labels: ["type:feature", "needs:info", "repository:addons-server"]
+projects: []
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: |
+        A few sentences describing what the task aims to achieve. It can be a simple sentence or a story formatted paragraph.
+        Be concise and detailed. Avoid vague terms and include relevant links.
+      placeholder: |
+        As a <blank>, I want to <blank, so that I can <blank>
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: List of milestones or checkpoints that if met verify the task has been completed.
+      value: |
+        ```[tasklist]
+          ### Acceptance Criteria
+          - [ ] 
+          ```
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      description: Checks before submitting the issue
+      options:
+        -
+          label: If the issue is ready to work on, I have removed the "needs:info" label and added an assignee.
+          required: true


### PR DESCRIPTION
Relates to: https://mozilla-hub.atlassian.net/browse/AMO-212

### Description

Add task and bug issue types with relevant labels applied. Allow specifying repository.

### Context

Docs for making issue templates/forms https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms

### Testing

I added these configurations to a test repo to verify what their effect is.

### Issue landing page

<img width="2037" alt="image" src="https://github.com/mozilla/addons/assets/19595165/dfda119e-b39a-447c-ac34-ba14e7f36b51">

### Issue bug form

https://github.com/mozilla/addons/assets/19595165/29f2098c-bba9-45ad-b4b0-ba893f470148

### Issue task form

https://github.com/mozilla/addons/assets/19595165/8d6fccfb-3d5b-4e42-ab4d-e7675c1f89fb

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/AMO11-6)
