### PR TITLE
Add workflow to transfer issues from another mozilla repository

### DIFF
--- a/.github/workflows/transfer-issues.yml
+++ b/.github/workflows/transfer-issues.yml
@@ -20,6 +20,9 @@ on:
         description: How many issues to transfer
         default: "1"
         required: true
+      issue_number:
+        description: "the issue number to transfer. Overrides count if set."
+        required: false
       from_name:
         description: "the name of the mozilla/<from_name repository to transfer issues from"
         required: true
@@ -28,9 +31,6 @@ on:
         required: true
 
 permissions: write-all
-
-env:
-  ALLOWED_REPOS: "addons-server,addons-frontend"
 
 concurrency:
   group: transfer
@@ -44,77 +44,15 @@ jobs:
 
       - name: Transfer issues
         env:
+          ALLOWED_REPOS: "addons-server,addons-frontend"
           GH_TOKEN: ${{ secrets[format('{0}', inputs.secret_name)] }}
+          FROM_NAME: ${{ inputs.from_name }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          TO_NAME: ${{ github.event.repository.name }}
+          COUNT: ${{ inputs.count }}
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
         shell: bash
-        run: |
-          set -x
-
-          echo "token: $GH_TOKEN"
-          gh auth status
-          
-          from_name="${{ inputs.from_name }}"
-          repo_label="repository:$from_name"
-          allowed_repos="${{ env.ALLOWED_REPOS }}"
-          repository_owner="${{ github.repository_owner }}"
-          to_name="${{ github.event.repository.name }}"
-          count="${{ inputs.count }}"
-
-          if [[ ! "$allowed_repos" =~ (^|,)"$from_name"(,|$) ]]; then
-            echo "Invalid from_name "$from_name". Exiting..."
-            exit 1
-          fi
-
-          echo "Transferring issues from \"$repository_owner/$from_name\" to \"$repository_owner/$to_name\""
-
-          repository_id=$(gh repo view "$repository_owner/$to_name" --json id --jq '.id')
-
-          issues_query="""
-            query {
-              repository(owner: \"$repository_owner\", name: \"$from_name\") {
-                issues(first: $count, orderBy: {field: CREATED_AT, direction: ASC}) {
-                  nodes {
-                    id
-                  }
-                }
-              }
-            }
-          """
-
-          issues=$(gh api graphql -f query="$issues_query" --jq '.data.repository.issues.nodes[].id')
-
-          transfer_mutation="mutation {"
-
-          new_issues_counter=1
-
-          while IFS= read -r issue_id; do
-            transfer_mutation+=" t${new_issues_counter}: transferIssue(input: { issueId: \"${issue_id}\", repositoryId: \"${repository_id}\", createLabelsIfMissing: true }) { issue { id url } }"
-            new_issues_counter=$((new_issues_counter+1))
-          done <<< "$issues"
-
-          transfer_mutation+=" }"
-
-          new_issues=$(gh api graphql -f query="$transfer_mutation" --jq '.data | keys[] as $k | {url: .[$k].issue.url, id: .[$k].issue.id}')
-
-          new_issue_ids=$(echo "$new_issues" | jq -r '.id')
-          
-          gh label create \"$repo_label\" -R "$repository_owner/$to_name" --force
-
-          label_id=$(gh api /repos/$repository_owner/$to_name/labels/$repo_label --jq '.node_id')
-
-          label_mutation="mutation {"
-
-          label_counter=1
-
-          while IFS= read -r id; do
-            label_mutation+=" l${label_counter}: updateIssue(input: {id: \"$id\", labelIds: [\"$label_id\"]}) { __typename }"
-            label_counter=$((label_counter+1))
-          done <<< "$new_issue_ids"
-
-          label_mutation+=" }"
-
-          gh api graphql -f query="$label_mutation"
-
-          echo "$new_issues" | jq -r '.url'
+        run: ./scripts/transfer-issues.sh
 
       - name: Delete secret
         if: always()
@@ -126,4 +64,3 @@ jobs:
           if gh secret list --json name --jq '.[] | .name' | grep -q "${{ inputs.secret_name }}"; then
             gh secret delete ${{ inputs.secret_name }}
           fi
-          

--- a/.github/workflows/transfer-issues.yml
+++ b/.github/workflows/transfer-issues.yml
@@ -1,0 +1,82 @@
+name: Transfer issues
+
+on:
+  workflow_dispatch:
+    inputs:
+      count:
+        description: How many issues to transfer
+        default: "1"
+        required: true
+      from_name:
+        description: "the name of the mozilla/<from_name repository to transfer issues from"
+        required: true
+
+permissions: write-all
+
+env:
+  ALLOWED_REPOS: "addons-server,addons-frontend"
+
+concurrency:
+  group: transfer
+  cancel-in-progress: true
+
+jobs:
+  fetch_issues:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - id: meta
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          if [[ ! "${{ env.ALLOWED_REPOS }}" =~ (^|,)"${{ inputs.from_name }}"(,|$) ]]; then
+            echo "Invalid from_name "${{ inputs.from_name }}". Exiting..."
+            exit 1
+          fi
+
+          echo "from_repo=${{ github.server_url }}/${{ github.repository_owner }}/${{ inputs.from_name }}" >> $GITHUB_OUTPUT
+          echo "to_repo=${{ github.server_url }}/${{ github.repository }}" >> $GITHUB_OUTPUT
+          echo "repo_label=repository:${{ inputs.from_name }}" >> $GITHUB_OUTPUT
+
+      - name: Transfer
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -x
+
+          gh auth status
+
+          gh label clone ${{ steps.meta.outputs.from_repo }} -R ${{ steps.meta.outputs.to_repo }} --force
+
+          gh label create ${{ steps.meta.outputs.repo_label }} -R ${{ steps.meta.outputs.to_repo }} --force
+
+          transfer_issue() {
+            original_issue_url=$1
+            from_repo=$2
+            to_repo=$3
+            repo_label=$4
+
+            echo "$original_issue_url" >> old-issues.txt
+
+            new_issue_url=$(gh issue transfer -R $from_repo "$original_issue_url" "$to_repo")
+
+            echo "$new_issue_url" >> new-issues.txt
+
+            echo "Transferred issue $original_issue_url to $new_issue_url"
+
+            gh issue -R $to_repo edit $new_issue_url --add-label $repo_label
+          }
+
+          export -f transfer_issue
+
+          echo "Transferring issues from \"${{ steps.meta.outputs.from_repo }}\" to \"${{ steps.meta.outputs.to_repo }}\""
+
+          gh issue list -R "${{ steps.meta.outputs.from_repo }}" -s all -L ${{ inputs.count}} --json url --search "sort:created-asc" --jq '.[] | .url'| xargs -P 4 -I % bash -c -e 'transfer_issue % '"${{ steps.meta.outputs.from_repo }}"' '"${{ steps.meta.outputs.to_repo }}"' '"${{ steps.meta.outputs.repo_label }}"''
+
+          cat old-issues.txt
+
+          cat new-issues.txt

--- a/.github/workflows/transfer-issues.yml
+++ b/.github/workflows/transfer-issues.yml
@@ -1,5 +1,18 @@
 name: Transfer issues
 
+# To run this action.
+# 1. Create a personal access token (Classic) with the `repo` and `read:org` scopes.defaults:
+# 2. Create a secret in the repository with whatever name you want, and paste the token as the value.
+# 3. Run the action with the secret name as the `secret_name` input.
+#
+# Ex: gh secret set MY_TOKEN --body "<token_value>" && gh workflow run 90730614 --field count="10" --field from_name="addons-server" --field secret_name="MY_TOKEN"
+#
+# Note: you need to paste the PAT in body, so make sure to keep track of the value before saving it.
+# Also verify the workflow ID is correct. You can run without arguments and select interactively.
+#
+# Note: After each run this action purges the secret from the repo action secrets.
+# This prevents pollution or conflict. So you have to reset it every time.
+
 on:
   workflow_dispatch:
     inputs:
@@ -9,6 +22,9 @@ on:
         required: true
       from_name:
         description: "the name of the mozilla/<from_name repository to transfer issues from"
+        required: true
+      secret_name:
+        description: "the name of the secret containing the PAT for the repository to transfer issues to"
         required: true
 
 permissions: write-all
@@ -25,58 +41,89 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - id: meta
-        if: github.event_name == 'workflow_dispatch'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
-        run: |
-          if [[ ! "${{ env.ALLOWED_REPOS }}" =~ (^|,)"${{ inputs.from_name }}"(,|$) ]]; then
-            echo "Invalid from_name "${{ inputs.from_name }}". Exiting..."
-            exit 1
-          fi
 
-          echo "from_repo=${{ github.server_url }}/${{ github.repository_owner }}/${{ inputs.from_name }}" >> $GITHUB_OUTPUT
-          echo "to_repo=${{ github.server_url }}/${{ github.repository }}" >> $GITHUB_OUTPUT
-          echo "repo_label=repository:${{ inputs.from_name }}" >> $GITHUB_OUTPUT
-
-      - name: Transfer
-        if: github.event_name == 'workflow_dispatch'
+      - name: Transfer issues
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets[format('{0}', inputs.secret_name)] }}
         shell: bash
         run: |
           set -x
 
+          echo "token: $GH_TOKEN"
           gh auth status
+          
+          from_name="${{ inputs.from_name }}"
+          repo_label="repository:$from_name"
+          allowed_repos="${{ env.ALLOWED_REPOS }}"
+          repository_owner="${{ github.repository_owner }}"
+          to_name="${{ github.event.repository.name }}"
+          count="${{ inputs.count }}"
 
-          gh label clone ${{ steps.meta.outputs.from_repo }} -R ${{ steps.meta.outputs.to_repo }} --force
+          if [[ ! "$allowed_repos" =~ (^|,)"$from_name"(,|$) ]]; then
+            echo "Invalid from_name "$from_name". Exiting..."
+            exit 1
+          fi
 
-          gh label create ${{ steps.meta.outputs.repo_label }} -R ${{ steps.meta.outputs.to_repo }} --force
+          echo "Transferring issues from \"$repository_owner/$from_name\" to \"$repository_owner/$to_name\""
 
-          transfer_issue() {
-            original_issue_url=$1
-            from_repo=$2
-            to_repo=$3
-            repo_label=$4
+          repository_id=$(gh repo view "$repository_owner/$to_name" --json id --jq '.id')
 
-            echo "$original_issue_url" >> old-issues.txt
+          issues_query="""
+            query {
+              repository(owner: \"$repository_owner\", name: \"$from_name\") {
+                issues(first: $count, orderBy: {field: CREATED_AT, direction: ASC}) {
+                  nodes {
+                    id
+                  }
+                }
+              }
+            }
+          """
 
-            new_issue_url=$(gh issue transfer -R $from_repo "$original_issue_url" "$to_repo")
+          issues=$(gh api graphql -f query="$issues_query" --jq '.data.repository.issues.nodes[].id')
 
-            echo "$new_issue_url" >> new-issues.txt
+          transfer_mutation="mutation {"
 
-            echo "Transferred issue $original_issue_url to $new_issue_url"
+          new_issues_counter=1
 
-            gh issue -R $to_repo edit $new_issue_url --add-label $repo_label
-          }
+          while IFS= read -r issue_id; do
+            transfer_mutation+=" t${new_issues_counter}: transferIssue(input: { issueId: \"${issue_id}\", repositoryId: \"${repository_id}\", createLabelsIfMissing: true }) { issue { id url } }"
+            new_issues_counter=$((new_issues_counter+1))
+          done <<< "$issues"
 
-          export -f transfer_issue
+          transfer_mutation+=" }"
 
-          echo "Transferring issues from \"${{ steps.meta.outputs.from_repo }}\" to \"${{ steps.meta.outputs.to_repo }}\""
+          new_issues=$(gh api graphql -f query="$transfer_mutation" --jq '.data | keys[] as $k | {url: .[$k].issue.url, id: .[$k].issue.id}')
 
-          gh issue list -R "${{ steps.meta.outputs.from_repo }}" -s all -L ${{ inputs.count}} --json url --search "sort:created-asc" --jq '.[] | .url'| xargs -P 4 -I % bash -c -e 'transfer_issue % '"${{ steps.meta.outputs.from_repo }}"' '"${{ steps.meta.outputs.to_repo }}"' '"${{ steps.meta.outputs.repo_label }}"''
+          new_issue_ids=$(echo "$new_issues" | jq -r '.id')
+          
+          gh label create \"$repo_label\" -R "$repository_owner/$to_name" --force
 
-          cat old-issues.txt
+          label_id=$(gh api /repos/$repository_owner/$to_name/labels/$repo_label --jq '.node_id')
 
-          cat new-issues.txt
+          label_mutation="mutation {"
+
+          label_counter=1
+
+          while IFS= read -r id; do
+            label_mutation+=" l${label_counter}: updateIssue(input: {id: \"$id\", labelIds: [\"$label_id\"]}) { __typename }"
+            label_counter=$((label_counter+1))
+          done <<< "$new_issue_ids"
+
+          label_mutation+=" }"
+
+          gh api graphql -f query="$label_mutation"
+
+          echo "$new_issues" | jq -r '.url'
+
+      - name: Delete secret
+        if: always()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets[format('{0}', inputs.secret_name)] }}
+        run: |
+          set -x
+          if gh secret list --json name --jq '.[] | .name' | grep -q "${{ inputs.secret_name }}"; then
+            gh secret delete ${{ inputs.secret_name }}
+          fi
+          

--- a/.github/workflows/transfer-issues.yml
+++ b/.github/workflows/transfer-issues.yml
@@ -4,6 +4,8 @@ name: Transfer issues
 #
 # 1. Create a personal access token (Classic) with the `repo` and `read:org` scopes.
 #
+# URL: https://github.com/settings/tokens/new?description=transfer-issues-token&scopes=repo,read:org
+#
 # 2. Authorize the token for use with [SAML](https://github.com/latest/authentication/authenticating-with-saml-single-sign-on/authorizing-a-personal-access-token-for-use-with-saml-single-sign-on) on the `mozilla` org.
 #
 # 3. Create a secret in the repository with whatever name you want, and paste the token as the value.

--- a/.github/workflows/transfer-issues.yml
+++ b/.github/workflows/transfer-issues.yml
@@ -1,11 +1,18 @@
 name: Transfer issues
 
-# To run this action.
-# 1. Create a personal access token (Classic) with the `repo` and `read:org` scopes.defaults:
-# 2. Create a secret in the repository with whatever name you want, and paste the token as the value.
-# 3. Run the action with the secret name as the `secret_name` input.
+# To run this action. You need to do the following:
 #
-# Ex: gh secret set MY_TOKEN --body "<token_value>" && gh workflow run 90730614 --field count="10" --field from_name="addons-server" --field secret_name="MY_TOKEN"
+# 1. Create a personal access token (Classic) with the `repo` and `read:org` scopes.
+#
+# 2. Authorize the token for use with [SAML](https://github.com/latest/authentication/authenticating-with-saml-single-sign-on/authorizing-a-personal-access-token-for-use-with-saml-single-sign-on) on the `mozilla` org.
+#
+# 3. Create a secret in the repository with whatever name you want, and paste the token as the value.
+#
+# ex: $ gh secret set <secret-name> --body "<token_value>
+#
+# 4. Run the action with the secret name as the `secret_name` input.
+#
+# ex: `gh secret set <secret-name> --body "<token_value>" && gh workflow run 90730614 --field count="10" --field from_name="addons-server" --field secret_name="<secret-name>"`
 #
 # Note: you need to paste the PAT in body, so make sure to keep track of the value before saving it.
 # Also verify the workflow ID is correct. You can run without arguments and select interactively.
@@ -47,7 +54,7 @@ jobs:
           ALLOWED_REPOS: "addons-server,addons-frontend"
           GH_TOKEN: ${{ secrets[format('{0}', inputs.secret_name)] }}
           FROM_NAME: ${{ inputs.from_name }}
-          REPO_OWNER: ${{ github.repository_owner }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
           TO_NAME: ${{ github.event.repository.name }}
           COUNT: ${{ inputs.count }}
           ISSUE_NUMBER: ${{ inputs.issue_number }}

--- a/scripts/transfer-issues.sh
+++ b/scripts/transfer-issues.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+set -x
+
+COUNT=${COUNT:-1}
+ISSUE_NUMBER=${ISSUE_NUMBER:-}
+
+set -u
+
+# Required environment variables
+# GITHUB_TOKEN: GitHub token with repo scope
+# REPOSITORY_OWNER: GitHub repository owner
+# FROM_NAME: Repository name to transfer issues from
+# TO_NAME: Repository name to transfer issues to
+# ALLOWED_REPOS: Comma-separated list of allowed repositories
+
+# Optional environment variables
+# ISSUE_NUMBER: Issue number to transfer (will nullify COUNT)
+# COUNT: Number of issues to transfer
+
+FROM_REPO="$REPOSITORY_OWNER/$FROM_NAME"
+TO_REPO="$REPOSITORY_OWNER/$TO_NAME"
+
+echo """
+REPOSITORY_OWNER: $REPOSITORY_OWNER
+FROM_NAME: $FROM_NAME
+TO_NAME: $TO_NAME
+ALLOWED_REPOS: $ALLOWED_REPOS
+
+FROM_REPO: $FROM_REPO
+TO_REPO: $TO_REPO
+
+ISSUE_NUMBER: $ISSUE_NUMBER
+COUNT: $COUNT
+"""
+
+auth_status=$(gh auth status 2>&1)
+
+if [[ "$auth_status" == *"You are not logged into any GitHub hosts."* ]]; then
+  echo "Error: $auth_status"
+  exit 1
+fi
+
+if [[ ! "$ALLOWED_REPOS" =~ (^|,)"$FROM_NAME"(,|$) ]]; then
+  echo "Invalid FROM_NAME "$FROM_NAME". Exiting..."
+  exit 1
+fi
+
+function get_single_issue() {
+  local issues_query="""
+    query {
+      repository(owner: \"$REPOSITORY_OWNER\", name: \"$FROM_NAME\") {
+        issue(number: $ISSUE_NUMBER) {
+          id
+        }
+      }
+    }
+  """
+
+  local issues=$(gh api graphql -f query="$issues_query" --jq '.data.repository.issue.id')
+
+  echo "$issues"
+}
+
+function get_multiple_issues() {
+  local issues_query="""
+    query {
+      repository(owner: \"$REPOSITORY_OWNER\", name: \"$FROM_NAME\") {
+        issues(first: $COUNT, orderBy: {field: CREATED_AT, direction: ASC}) {
+          nodes {
+            id
+          }
+        }
+      }
+    }
+  """
+
+  local issues=$(gh api graphql -f query="$issues_query" --jq '.data.repository.issues.nodes[].id')
+
+  echo "$issues"
+}
+
+if [[ -n "$ISSUE_NUMBER" ]]; then
+  echo "Transferring issue $ISSUE_NUMBER from \"$FROM_REPO\" to \"$TO_REPO\""
+  issues=$(get_single_issue)
+else
+  echo "Transferring $COUNT issues from \"$FROM_REPO\" to \"$TO_REPO\""
+  issues=$(get_multiple_issues)
+fi
+
+transfer_mutation="mutation {"
+
+new_issues_counter=1
+
+repository_id=$(gh repo view "$TO_REPO" --json id --jq '.id')
+
+while IFS= read -r issue_id; do
+  transfer_mutation+=" t${new_issues_counter}: transferIssue(input: { issueId: \"${issue_id}\", repositoryId: \"${repository_id}\", createLabelsIfMissing: true }) { issue { id url } }"
+  new_issues_counter=$((new_issues_counter+1))
+done <<< "$issues"
+
+transfer_mutation+=" }"
+
+new_issues=$(gh api graphql -f query="$transfer_mutation" --jq '.data | keys[] as $k | {url: .[$k].issue.url, id: .[$k].issue.id}')
+
+repo_label="repository:$FROM_NAME"
+
+gh label create \"$repo_label\" -R "$TO_REPO" --force
+
+label_id=$(gh api /repos/$TO_REPO/labels/$repo_label --jq '.node_id')
+
+label_mutation="mutation {"
+
+label_counter=1
+
+while IFS= read -r id; do
+  label_mutation+=" l${label_counter}: updateIssue(input: {id: \"$id\", labelIds: [\"$label_id\"]}) { __typename }"
+  label_counter=$((label_counter+1))
+done <<< $(echo "$new_issues" | jq -r '.id')
+
+label_mutation+=" }"
+
+gh api graphql -f query="$label_mutation"
+
+echo "$new_issues" | jq -r '.url'


### PR DESCRIPTION
Relates to: https://mozilla-hub.atlassian.net/browse/AMO-212

### Description
This pull request adds a workflow that can be used to transfer GitHub issues from one repository to another. The script uses the GitHub CLI tool to list all issues, sort them by creation date, and transfer them to a specified repository. This script can be useful when migrating repositories or consolidating multiple repositories into one.

### Context

We can specify the repository and number of issues to transfer. Alternatively you can specify a specific issue to transfer. There is only minimal validation currently but errors should be propagated and have been roughly tested if you give an issue that doesn't belong to the repo, or a repo that doesn't exist, or a count of 0.

It turns out to be easier to run this script on the addons repo rather than the addons-server repo as we have a token for "addons", also transferring multiple repos to addons is easier achieved with the script configured here.

### Testing

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/AMO11-8)
