### PR TITLE
Update issue templates to not ask about an issue having an assignee to be ready

### DIFF
--- a/.github/ISSUE_TEMPLATE/task-addons-frontend.yml
+++ b/.github/ISSUE_TEMPLATE/task-addons-frontend.yml
@@ -34,5 +34,5 @@ body:
       description: Checks before submitting the issue
       options:
         -
-          label: If the issue is ready to work on, I have removed the "needs:info" label and added an assignee.
+          label: If the issue is ready to work on, I have removed the "needs:info" label.
           required: true

--- a/.github/ISSUE_TEMPLATE/task-addons-server.yml
+++ b/.github/ISSUE_TEMPLATE/task-addons-server.yml
@@ -34,5 +34,5 @@ body:
       description: Checks before submitting the issue
       options:
         -
-          label: If the issue is ready to work on, I have removed the "needs:info" label and added an assignee.
+          label: If the issue is ready to work on, I have removed the "needs:info" label.
           required: true


### PR DESCRIPTION
As title.

As currently worded the template implies that for an issue to be ready to be worked on it must have an assignee already, which isn't always the case - we file issues as needed, but only assign them once we know who is working on them, and that it will happen in the next sprint or so.

I don't think this is possible to test before merging.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/AMO11-44)
