### PR TITLE
Allow filtering by issue state (open or closed or both)

### DIFF
--- a/.github/workflows/transfer-issues.yml
+++ b/.github/workflows/transfer-issues.yml
@@ -38,6 +38,10 @@ on:
       secret_name:
         description: "the name of the secret containing the PAT for the repository to transfer issues to"
         required: true
+      states:
+        description: "which states to include 1) [OPEN] 2) [OPEN, CLOSED]"
+        required: true
+        default: "[OPEN]"
 
 permissions: write-all
 

--- a/scripts/transfer-issues.sh
+++ b/scripts/transfer-issues.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-set -x
-
 COUNT=${COUNT:-1}
+STATES=${STATES:-"[OPEN, CLOSED]"}
 ISSUE_NUMBER=${ISSUE_NUMBER:-}
 
 set -u
@@ -32,6 +31,7 @@ TO_REPO: $TO_REPO
 
 ISSUE_NUMBER: $ISSUE_NUMBER
 COUNT: $COUNT
+STATES: $STATES
 """
 
 auth_status=$(gh auth status 2>&1)
@@ -66,7 +66,7 @@ function get_multiple_issues() {
   local issues_query="""
     query {
       repository(owner: \"$REPOSITORY_OWNER\", name: \"$FROM_NAME\") {
-        issues(first: $COUNT, orderBy: {field: CREATED_AT, direction: ASC}) {
+        issues(first: $COUNT, states: $STATES, orderBy: {field: CREATED_AT, direction: ASC}) {
           nodes {
             id
           }


### PR DESCRIPTION
### Description

Allow filtering by state so we can transfer only open issues first.

### Context

When we run the migration we want to transfer the open issues first. THis let's us do that and continue with closed issues without needing further code changes.

### Testing

You can test locally.

1. authenticate with github cli

```bash
gh login
```

2. Run a command to transfer an issue

```bash
FROM_NAME=addons-server STATES="[OPEN]" ./scripts/transfer-issues.sh
```

NOTE: this will actually transfer the issue. Wild west.

#### Testing in CI

You can test the action in GHA by triggering [manually](https://github.com/mozilla/addons/actions/workflows/transfer-issues.yml)

<img width="459" alt="image" src="https://github.com/mozilla/addons/assets/19595165/bcefc41f-173c-4756-95e2-de531d711d58">

Make sure to set the branch to `transfer-via-state` so it runs on this PR branch.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/AMO2-60)
