### PR TITLE
Map states input to STATES environment variable to make state selection configurable from CLI

### DIFF
--- a/.github/workflows/transfer-issues.yml
+++ b/.github/workflows/transfer-issues.yml
@@ -63,6 +63,8 @@ jobs:
           # One or the other is required
           COUNT: ${{ inputs.count }}
           ISSUE_NUMBER: ${{ inputs.issue_number }}
+          # Optional input
+          STATES: ${{ inputs.states }}
         shell: bash
         run: ./scripts/transfer-issues.sh
 


### PR DESCRIPTION
Forgot to map the input "states" to the environment variable "STATES" allowing the action to specify targeting open,closed, or both states.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/AMO2-78)
