### PR TITLE
Github template updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,7 @@
 name: Bug Report
 description: File a bug report
 title: "[Bug]: "
+type: bug
 labels: ["type:bug", "needs:info"]
 projects: []
 body:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: AMO Matrix channel
     url: https://matrix.to/#/#amo:mozilla.org

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -22,7 +22,7 @@ body:
       label: Acceptance Criteria
       description: List of milestones or checkpoints that if met verify the task has been completed.
       value: |
-          - [ ] task 1
+          - [ ] item 1
     validations:
       required: true
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -25,12 +25,4 @@ body:
           - [ ] item 1
     validations:
       required: true
-  - type: checkboxes
-    id: checks
-    attributes:
-      label: Checks
-      description: Checks before submitting the issue
-      options:
-        - label: If I have identified that the work is specific to a repository, I have removed "repository:addons-server" or "repository:addons-frontend"
-          required: true
 

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,7 +1,8 @@
-name: Task/Feature request
-description: Filing a Task/Feature request
-title: "[Task]: "
-labels: ["type:feature", "needs:info", "repository:addons-server", "repository:addons-frontend"]
+name: Feature request
+description: Filing a Feature request
+title: "[Feature]: "
+type: feature
+labels: ["type:feature", "needs:info"]
 projects: []
 body:
   - type: textarea
@@ -9,7 +10,7 @@ body:
     attributes:
       label: Description
       description: |
-        A few sentences describing what the task aims to achieve. It can be a simple sentence or a story formatted paragraph.
+        A few sentences describing what the feature aims to achieve. It can be a simple sentence or a story formatted paragraph.
         Be concise and detailed. Avoid vague terms and include relevant links.
       placeholder: |
         As a <blank>, I want to <blank, so that I can <blank>
@@ -21,10 +22,7 @@ body:
       label: Acceptance Criteria
       description: List of milestones or checkpoints that if met verify the task has been completed.
       value: |
-        ```[tasklist]
-          ### Milestones/checkpoints
-          - [ ] A sentence describing the first milestone/checkpoint
-        ```
+          - [ ] task 1
     validations:
       required: true
   - type: checkboxes
@@ -35,4 +33,4 @@ body:
       options:
         - label: If I have identified that the work is specific to a repository, I have removed "repository:addons-server" or "repository:addons-frontend"
           required: true
-  
+

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,6 +1,6 @@
-name: Feature request
-description: Filing a Feature request
-title: "[Feature]: "
+name: Task/Feature request
+description: Filing a Task/Feature request
+title: "[Task]: "
 type: feature
 labels: ["type:feature", "needs:info"]
 projects: []

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,43 @@
+Fixes: mozilla/addons#ISSUENUM
+
+<!--
+Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
+-->
+
+### Description
+
+<!--
+Your PR will be squashed when merged so the 1st commit must contain a descriptive and concise summary of the change.
+Additional details should be added in the description. If your change is simple enough to summarize in the commit, or
+if it is not relevant for your PR, remove this section.
+-->
+
+### Context
+
+<!--
+Often a pull request contains changes that are not fully self explanatory. Maybe this PR is a part of a series,
+or maybe it is a partial change now with a more ambitious plan for the future. Add this additional context here.
+If it is not relevant for your PR, remove this section.
+-->
+
+### Testing
+
+<!--
+Your change must be related to an existing, open issue. This issue should contain testing instructions.
+Often, the testing info in the issue is higher level, geared towards a user or QA experience.
+Here you can provide information for a developer verifying this PR. Get technical.
+If it is not relevant to your PR, remove this section.
+-->
+
+### Checklist
+
+<!--
+Here's a few guidelines as to what we need in your PR before we review it.
+Please delete anything that isn't relevant to your patch.
+-->
+
+- [ ] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
+- [ ] Successfully verified the change locally.
+- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
+- [ ] Add before and after screenshots (Only for changes that impact the UI).
+- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.


### PR DESCRIPTION
fixes: mozilla/addons#15401

- Introduced a new pull request template to standardize submissions.
- Added a feature request template with fields for description and acceptance criteria.
- Updated the bug report template to include a type field.
- Enabled blank issues in the configuration for more flexibility.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/AMOENG-1556)
