### PR TITLE
disable blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: AMO Matrix channel
     url: https://matrix.to/#/#amo:mozilla.org


### PR DESCRIPTION
With the blank issue fallback issues can be created without the `needs:info` label