### PR TITLE
Enhance Slack action with dry run functionality and update CI workflow

### DIFF
--- a/.github/actions/slack/action.yml
+++ b/.github/actions/slack/action.yml
@@ -20,8 +20,43 @@ runs:
   using: 'composite'
 
   steps:
+  - name: Validate payload
+    shell: bash
+    env:
+      payload: ${{ inputs.payload }}
+    run: |
+      if [ -z "${payload}" ]; then
+        echo "payload is empty"
+        exit 1
+      fi
+
+      # Validate that payload is valid YAML
+      echo "${payload}" | yq e '.'
+
+      # Validate that payload has "channel" field
+      channel_value=$(echo "${payload}" | yq e '.channel' -)
+      if [ "${channel_value}" = "null" ] || [ -z "${channel_value}" ]; then
+        echo "payload is missing channel field"
+        exit 1
+      fi
+
   - name: Context
     id: context
+    shell: bash
+    env:
+      dry_run: ${{ inputs.dry_run }}
+    run: |
+      send_message=true
+
+      if [ -n "${dry_run}" ] && [ "${dry_run}" != "false" ] && [ "${dry_run}" != "null" ]; then
+        send_message=false
+      fi
+
+      echo "send_message=${send_message}" >> "${GITHUB_OUTPUT}"
+      cat "${GITHUB_OUTPUT}"
+
+  - name: Send Message (dry run)
+    if: ${{ steps.context.outputs.send_message == 'false' }}
     shell: bash
     env:
       payload: ${{ inputs.payload }}
@@ -34,7 +69,7 @@ runs:
       echo "${payload}"
 
   - name: Send Message
-    if: ${{ !inputs.dry_run }}
+    if: ${{ steps.context.outputs.send_message == 'true' }}
     uses: slackapi/slack-github-action@v2.0.0
     with:
       errors: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,190 @@
 name: CI
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
 
+env:
+  SLACK_CHANNEL: ${{ vars.SLACK_CHANNEL_TEST }}
+
 jobs:
-  slack_workflow_notification:
+  slack_action_payload:
     runs-on: ubuntu-latest
+    name: Test Slack Action ${{ matrix.name }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - name: Test with no context or links
+          -
+            name: "Payload has empty text"
+            payload: |
+              channel: ${{ vars.SLACK_CHANNEL_TEST }}
+              text: ""
+            expect_failure: false
+          -
+            name: "Payload is undefined"
+            expect_failure: true
+          -
+            name: "Payload has text"
+            payload: |
+              channel: ${{ vars.SLACK_CHANNEL_TEST }}
+              text: "Hello, world!"
+            expect_failure: false
+          -
+            name: "Payload has number text"
+            payload: |
+              channel: ${{ vars.SLACK_CHANNEL_TEST }}
+              text: 123
+            expect_failure: false
+          -
+            name: "Payload has boolean text"
+            payload: |
+              channel: ${{ vars.SLACK_CHANNEL_TEST }}
+              text: true
+            expect_failure: false
+          -
+            name: "Payload has complex object"
+            payload: |
+              channel: ${{ vars.SLACK_CHANNEL_TEST }}
+              text: "Deployment started :eyes:"
+              attachments:
+                - color: "dbab09"
+                  fields:
+                    - title: "Status"
+                      short: true
+                      value: "In Progress"
+            expect_failure: false
+          -
+            name: "Payload has invalid JSON"
+            payload: |
+              channel: ${{ vars.SLACK_CHANNEL_TEST }}
+              text: |
+                { 3: "thing", null }
+            expect_failure: false
+          -
+            name: "Payload missing channel"
+            payload: |
+              text: "Hello, world!"
+            expect_failure: true
+          -
+            name: "Payload with very long text"
+            payload: |
+              channel: ${{ vars.SLACK_CHANNEL_TEST }}
+              text: "This is a very long message that exceeds normal limits and should test how the system handles extremely long text content that might cause issues with Slack API limits or YAML parsing. It contains many characters and should be properly handled by the validation logic."
+            expect_failure: false
+          -
+            name: "Payload with special characters"
+            payload: |
+              channel: ${{ vars.SLACK_CHANNEL_TEST }}
+              text: "Message with special chars: & < > \" ' \n \t \r"
+            expect_failure: false
+          -
+            name: "Payload with different method"
+            payload: |
+              channel: ${{ vars.SLACK_CHANNEL_TEST }}
+              text: "Testing different method"
+            method: chat.postEphemeral
+            expect_failure: false
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Slack Action Payload
+        id: slack
+        continue-on-error: true
+        uses: ./.github/actions/slack
+        with:
+          slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: ${{ matrix.payload}}
+          method: ${{ matrix.method || 'chat.postMessage' }}
+          dry_run: true
+
+      - name: "Verify outcome"
+        env:
+          result: ${{ steps.slack.outcome }}
+          expect_failure: ${{ matrix.expect_failure }}
+        run: |
+          if [[ "${expect_failure}" == "true" && "${result}" != "failure" ]]; then
+            echo "Expected failure!"
+            exit 1
+          fi
+          if [[ "${expect_failure}" == "false" && "${result}" != "success" ]]; then
+            echo "Expected success!"
+            exit 1
+          fi
+
+  slack_action_dry_run:
+    runs-on: ubuntu-latest
+    name: Test Slack Action ${{ matrix.name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          -
+            name: "Dry run is undefined"
+            expect_message: true
+          -
+            name: "Dry run is 'false'"
+            expect_message: true
+            dry_run: "false"
+          -
+            name: "Dry run is false"
+            expect_message: true
+            dry_run: false
+          -
+            name: "Dry run is 'true'"
+            expect_message: false
+            dry_run: "true"
+          -
+            name: "Dry run is true"
+            expect_message: false
+            dry_run: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Test Slack Action: ${{ matrix.name }}"
+        id: slack
+        continue-on-error: true
+        uses: ./.github/actions/slack
+        with:
+          # We explicitly don't pass the slack token so that we can test
+          # If the action actually attempts to send a message. This would
+          # fail and we can assert that an attempt was made to send the message.
+          # slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ vars.SLACK_CHANNEL_TEST }}
+            text: "Dry run is '${{ matrix.dry_run }}'"
+          method: chat.postMessage
+          dry_run: ${{ matrix.dry_run }}
+
+      - name: "Verify outcome"
+        env:
+          result: ${{ steps.slack.outcome }}
+          expect_message: ${{ matrix.expect_message }}
+        run: |
+          if [[ "${expect_message}" == "true" && "${result}" != "failure" ]]; then
+            echo "Expected message to be sent!"
+            exit 1
+          fi
+
+          if [[ "${expect_message}" == "false" && "${result}" == "failure" ]]; then
+            echo "Expected message to not be sent!"
+            exit 1
+          fi
+
+  slack_workflow_notification:
+    runs-on: ubuntu-latest
+    name: Test Slack Workflow Notification ${{ matrix.name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: with no context or links
             conclusion: success
             text: "push afd4d2f (Update Makefile-docker (#23610)"
             text_link: "https://github.com/mozilla/addons"
@@ -24,7 +196,7 @@ jobs:
               {
                 "one": "thing"
               }
-          - name: Test with links but no context
+          - name: with links but no context
             conclusion: success
             text: "push afd4d2f (Update Makefile-docker (#23610)"
             text_link: "https://github.com/mozilla/addons"
@@ -33,7 +205,7 @@ jobs:
                 "link1": "https://github.com/mozilla/addons",
                 "link2": "https://github.com/mozilla/addons"
               }
-          - name: Test with both context and links
+          - name: with both context and links
             conclusion: cancelled
             text: "push afd4d2f (Update Makefile-docker (#23610)"
             text_link: "https://github.com/mozilla/addons"
@@ -49,17 +221,48 @@ jobs:
                 "link2": "https://github.com/mozilla/addons",
                 "link3": "https://github.com/mozilla/addons"
               }
+          - name: with skipped conclusion
+            conclusion: skipped
+            text: "push afd4d2f (Update Makefile-docker (#23610)"
+            text_link: "https://github.com/mozilla/addons"
+          - name: with null text_link
+            conclusion: success
+            text: "push afd4d2f (Update Makefile-docker (#23610)"
+            text_link: "null"
+          - name: with empty context and links
+            conclusion: failure
+            text: "push afd4d2f (Update Makefile-docker (#23610)"
+            text_link: "https://github.com/mozilla/addons"
+            context: "{}"
+            links: "{}"
+          - name: with custom separator
+            conclusion: success
+            text: "push afd4d2f (Update Makefile-docker (#23610)"
+            text_link: "https://github.com/mozilla/addons"
+            context: |
+              {
+                "key1": "value1",
+                "key2": "value2"
+              }
+            links: |
+              {
+                "link1": "https://github.com/mozilla/addons"
+              }
+            separator: " • "
 
     steps:
+      - uses: actions/checkout@v4
+
       - name: Slack Workflow Notification
-        uses: mozilla/addons/.github/actions/slack-workflow-notification@${{ github.sha }}
+        uses: ./.github/actions/slack-workflow-notification
         with:
-          slack_token: ${{ secrets.SLACK_TOKEN }}
-          slack_channel: ${{ secrets.SLACK_CHANNEL }}
+          slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          slack_channel: ${{ vars.SLACK_CHANNEL_TEST }}
           conclusion: ${{ matrix.conclusion }}
           text: ${{ matrix.text }}
           text_link: ${{ matrix.text_link }}
-          context: ${{ toJSON(matrix.context) }}
-          links: ${{ toJSON(matrix.links) }}
+          context: ${{ matrix.context }}
+          links: ${{ matrix.links }}
+          separator: ${{ matrix.separator }}
           dry_run: true
 


### PR DESCRIPTION
Fixes: mozilla/addons#15730

### Description

- Added logic to determine if a message should be sent based on the dry_run input in action.yml.
- Updated the CI workflow to include a job that tests the Slack action with various dry_run values, ensuring comprehensive coverage of scenarios.

### Context

The conditional for either sending the slack message or just printing what would be sent is somehow extremely difficult to get right.

### Testing

We are now using bash to interpret the input and set an explicit value. Additionally we either send the message or print the message, not both.

### Checklist

- [ ] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
