### PR TITLE
Update zizmor, specifying cooldown for all ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,21 @@ updates:
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
+  cooldown:
+    default-days: 7
+  open-pull-requests-limit: 99
+- package-ecosystem: "docker-compose"
+  directory: "/"
+  schedule:
+    interval: weekly
+  cooldown:
+    default-days: 7
   open-pull-requests-limit: 99
 - package-ecosystem: pip
   directory: "/requirements"
   schedule:
     interval: daily
+  cooldown:
+    default-days: 7
   open-pull-requests-limit: 99

--- a/docker-compose.tools.yml
+++ b/docker-compose.tools.yml
@@ -13,6 +13,6 @@ services:
 
   zizmor:
     extends: base
-    image: ghcr.io/zizmorcore/zizmor:1.11.0@sha256:ecb5e81e47bdb9e61ffa26b3def736ef4a6842d25e106986fd9dc579da0c9a68
+    image: ghcr.io/zizmorcore/zizmor:1.18.0@sha256:c5bbdb28b75702f181695d7a878e562ccb5c0a01847db87edda7476908d73dd6
     environment:
       - GH_TOKEN


### PR DESCRIPTION
The latest version of zizmor checks for the `cooldown` parameter for all ecosystems, and dependabot documentation says that should work, so let's try that again.

`docker-compose` ecosystem is added to keep zizmor up to date.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/AMOENG-2162)
