### PR TITLE
Fix rendering issue with code block on Push Duty page

### DIFF
--- a/docs/server/push-duty.rst
+++ b/docs/server/push-duty.rst
@@ -126,7 +126,7 @@ before tagging, and then creating and pushing a git tag to the Extension
 Workshop repository will deploy it to production. You should manually
 verify the site on prod after the push has been completed. Visit
 https://extensionworkshop.com and view any pages that have been changed
-since the last push to verify they exist and are rendering properly.
+since the last push to verify they exist and are rendering properly. ::
 
     $ git checkout master
     $ git pull


### PR DESCRIPTION
Fixes: mozilla/addons#15990

<img width="871" height="386" alt="Screenshot 2025-12-19 at 8 59 14 AM" src="https://github.com/user-attachments/assets/46683a42-71df-4da4-8d46-d58b2cca00d9" />

### Testing

Tested locally by building the site and verifying the HTML output. This change does not modify automated tests because it addresses is a stylistic bug in the page content.

### Checklist

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [x] Add before and after screenshots (Only for changes that impact the UI).
- [x] Add or update relevant [docs](../docs/) reflecting the changes made.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/AMOENG-2205)
