### PR TITLE
Address security warnings in our GH actions

### DIFF
--- a/.github/actions/context/action.yml
+++ b/.github/actions/context/action.yml
@@ -74,16 +74,16 @@ runs:
       run: |
         # Stable check for if the workflow is running on the default branch
         # https://stackoverflow.com/questions/64781462/github-actions-default-branch-variable
-        is_default_branch="${{ format('refs/heads/{0}', env.default_branch) == github.ref }}"
+        is_default_branch="${{ env.ref_name == env.default_branch }}"
 
-        # In most events, the epository refers to the head which would be the fork
+        # In most events, the repository refers to the head which would be the fork
         is_fork="${{ github.event.repository.fork }}"
         # Default version is the branch name
         docker_version="${ref_name}"
 
         # This is different in a pull_request where we need to check the head explicitly
         if [[ "${{ github.event_name }}" == 'pull_request' ]]; then
-          # repository on a pull request refers to the base which is always mozilla/<repsotory>
+          # repository on a pull request refers to the base which is always mozilla/<repository>
           is_head_fork="${{ github.event.pull_request.head.repo.fork }}"
           # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions
           is_dependabot="${{ github.actor == 'dependabot[bot]' }}"

--- a/.github/actions/slack-workflow-notification/action.yml
+++ b/.github/actions/slack-workflow-notification/action.yml
@@ -93,12 +93,7 @@ runs:
         cat "${GITHUB_OUTPUT}"
 
     - name: Notify Slack
-      # This action uses another action defined in the same repository.
-      # Github action does not support dynamic version selection so we have to pick
-      # a single version. Pinning to a commit hash is not a great idea because we have to
-      #manage multiple cascading version updates for the action and this file cannot reference
-      # it's own git hash.
-      uses: mozilla/addons/.github/actions/slack@main # zizmor: ignore[unpinned-uses]
+      uses: mozilla/addons/.github/actions/slack@43401a931ebc09f2e511deed766171b0105414bc
       with:
         slack_token: ${{ inputs.slack_token }}
         method: chat.postMessage


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/security/code-scanning/1

- Avoid referencing `github.ref` in a `run:` block
- Pin our slack action (it's stable enough that it should be fine)