### PR TITLE
Add security bug link to new issue prompt; replace matrix with discourse

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
-  - name: AMO Matrix channel
-    url: https://matrix.to/#/#amo:mozilla.org
+  - name: Security Bug Report
+    url: https://www.mozilla.org/en-US/security/web-bug-bounty/
+    about: File security-related bugs via our bug bounty program
+  - name: AMO Discourse
+    url: https://discourse.mozilla.org/c/add-ons/35
     about: Please ask and answer questions here.


### PR DESCRIPTION
Prompted by https://mozilla-hub.atlassian.net/browse/AMOENG-2640, where we're making sure to highlight our security bug process, though not strictly a part of it.

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

As title, adds a link to the bug bounty program for security bugs, and switches out the link to our matrix channel to discourse, which is a better user experience for asynchronous support.

### Context

<!--
Often a pull request contains changes that are not fully self explanatory. Maybe this PR is a part of a series,
or maybe it is a partial change now with a more ambitious plan for the future. Add this additional context here.
If it is not relevant for your PR, remove this section.
-->

### Testing

<!--
Your change must be related to an existing, open issue. This issue should contain testing instructions.
Often, the testing info in the issue is higher level, geared towards a user or QA experience.
Here you can provide information for a developer verifying this PR. Get technical.
If it is not relevant to your PR, remove this section.
-->

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [ ] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
